### PR TITLE
rephrase "Should we add a Typescript support?" to "Would you like to use TypeScript?"

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -34,7 +34,7 @@ const questions: PromptObject<string>[] = [
     {
         type: (prev: string, answers: any) => (answers.template as TemplateModel).has_typescript ? 'select' : null,
         name: 'withTypescript',
-        message: 'Should we add a Typescript support?',
+        message: 'Would you like to use TypeScript?',
         choices: [
             { title: "Yes", value: true },
             { title: "No", value: false }


### PR DESCRIPTION
"Typescript support" sounds like the CLI is generating a tool which can handle TypeScript as an input, instead of using it as language for its source code